### PR TITLE
org-babel-get-header depreciated, replace with org-babel--get-vars

### DIFF
--- a/ob-mathematica.el
+++ b/ob-mathematica.el
@@ -28,7 +28,7 @@
 
 (defun org-babel-expand-body:mathematica (body params)
   "Expand BODY according to PARAMS, return the expanded body."
-  (let ((vars (mapcar #'cdr (org-babel-get-header params :var))))
+  (let ((vars (mapcar #'cdr (org-babel--get-vars params))))
     (concat
      (mapconcat ;; define any variables
       (lambda (pair)


### PR DESCRIPTION
See also [zweifisch/ob-http#12](https://github.com/zweifisch/ob-http/issues/12) and [gjkerns/ob-julia#5](https://github.com/gjkerns/ob-julia/issues/5) where the same fix was used.